### PR TITLE
Resolve warnings introduced in Elixir v1.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -41,11 +41,11 @@ defmodule Baud.Mixfile do
 
   defp aliases do
     [
-      "tryout": ["run script/tryout.exs"],
-      "long": ["run script/long.exs"],
-      "baud": ["run script/baud.exs"],
-      "master": ["run script/master.exs"],
-      "modport": ["run script/modport.exs"],
+      tryout: ["run script/tryout.exs"],
+      long: ["run script/long.exs"],
+      baud: ["run script/baud.exs"],
+      master: ["run script/master.exs"],
+      modport: ["run script/modport.exs"],
     ]
   end
 end


### PR DESCRIPTION
This commit fixes quotation warnings in `mix.exs`. The warnings were
introduced with Elixir v1.7. Example warning:

    warning: found quoted keyword "tryout" but the quotes are not
    required. Note that keywords are always atoms, even when quoted, and
    quotes should only be used to introduce keywords with foreign
    characters in them